### PR TITLE
Adding database retry logic

### DIFF
--- a/OctopusSamples.OctoPetShop.Database/Program.cs
+++ b/OctopusSamples.OctoPetShop.Database/Program.cs
@@ -10,43 +10,43 @@ namespace OctopusSamples.OctoPetShopDatabase
     {
         static int Main(string[] args)
         {
-			var retryCount = 0;
-			var environmentVariableConnectionString = Environment.GetEnvironmentVariable("DbUpConnectionString");
+            var retryCount = 0;
+            var environmentVariableConnectionString = Environment.GetEnvironmentVariable("DbUpConnectionString");
             var connectionString = environmentVariableConnectionString == null ? args.FirstOrDefault() ?? "Server=(local)\\SqlExpress; Database=ops; Trusted_connection=true" : environmentVariableConnectionString;
 
 
-			// retry three times
-			while (true)
-			{
-				try
-				{
-					EnsureDatabase.For.SqlDatabase(connectionString);
-					break;
-				}
-				catch (System.Data.SqlClient.SqlException)
-				{
-					// check type
-					if (retryCount < 3)
-					{
-						// Display
-						Console.WriteLine("Connection error occured, waiting 3 seconds then trying again.");
-						System.Threading.Thread.Sleep(3000);
-						retryCount += 1;
-					}
-					else
-					{
-						// rethrow
-						throw;
-					}
-				}
-			}
-			
+            // retry three times
+            while (true)
+            {
+                try
+                {
+                    EnsureDatabase.For.SqlDatabase(connectionString);
+                    break;
+                }
+                catch (System.Data.SqlClient.SqlException)
+                {
+                    // check type
+                    if (retryCount < 3)
+                    {
+                        // Display
+                        Console.WriteLine("Connection error occured, waiting 3 seconds then trying again.");
+                        System.Threading.Thread.Sleep(3000);
+                        retryCount += 1;
+                    }
+                    else
+                    {
+                        // rethrow
+                        throw;
+                    }
+                }
+            }
+
             var upgrader =
-                DeployChanges.To
-                    .SqlDatabase(connectionString)
-                    .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
-                    .LogToConsole()
-                    .Build();
+            DeployChanges.To
+            .SqlDatabase(connectionString)
+            .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
+            .LogToConsole()
+            .Build();
 
             var result = upgrader.PerformUpgrade();
 

--- a/OctopusSamples.OctoPetShop.Database/Program.cs
+++ b/OctopusSamples.OctoPetShop.Database/Program.cs
@@ -23,10 +23,10 @@ namespace OctopusSamples.OctoPetShopDatabase
 					EnsureDatabase.For.SqlDatabase(connectionString);
 					break;
 				}
-				catch (System.Exception e)
+				catch (System.Data.SqlClient.SqlException)
 				{
 					// check type
-					if (e.GetType() == typeof(System.Data.SqlClient.SqlException) && retryCount < 3)
+					if (retryCount < 3)
 					{
 						// Display
 						Console.WriteLine("Connection error occured, waiting 3 seconds then trying again.");
@@ -35,8 +35,8 @@ namespace OctopusSamples.OctoPetShopDatabase
 					}
 					else
 					{
-						// retrhow
-						throw e;
+						// rethrow
+						throw;
 					}
 				}
 			}

--- a/OctopusSamples.OctoPetShop.Database/Program.cs
+++ b/OctopusSamples.OctoPetShop.Database/Program.cs
@@ -42,11 +42,11 @@ namespace OctopusSamples.OctoPetShopDatabase
             }
 
             var upgrader =
-            DeployChanges.To
-            .SqlDatabase(connectionString)
-            .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
-            .LogToConsole()
-            .Build();
+                DeployChanges.To
+                   .SqlDatabase(connectionString)
+                   .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
+                   .LogToConsole()
+                   .Build();
 
             var result = upgrader.PerformUpgrade();
 

--- a/OctopusSamples.OctoPetShop.Database/Program.cs
+++ b/OctopusSamples.OctoPetShop.Database/Program.cs
@@ -41,8 +41,6 @@ namespace OctopusSamples.OctoPetShopDatabase
 				}
 			}
 			
-			
-
             var upgrader =
                 DeployChanges.To
                     .SqlDatabase(connectionString)


### PR DESCRIPTION
A person who was visiting our blog ran into an issue where the SQL Server container took too long to load which caused the database container to fail.  They were trying to follow along with the blog and this was catching them up.  I added retry logic to the DBUp project to try to prevent others from encountering the same issue.  If this PR is approved, I'll build the updated docker container and push it to Docker Hub.