### PR TITLE
Add --ConnectionString command line flag so Db.exe recognizes the connection string

### DIFF
--- a/OctopusSamples.OctoPetShop.Database/deploy.ps1
+++ b/OctopusSamples.OctoPetShop.Database/deploy.ps1
@@ -1,2 +1,2 @@
 $connectionString = $OctopusParameters["ConnectionStrings:OPSConnectionString"]
-.\OctopusSamples.OctoPetShop.Database.exe "$connectionString"
+.\OctopusSamples.OctoPetShop.Database.exe --ConnectionString="$connectionString"


### PR DESCRIPTION
There was an update to the Db project in [this PR](https://github.com/OctopusSamples/OctoPetShop/pull/13/files) that changed the interface to the program such that it expects a flag for the ConnectionString. This just adds this flag to the project's `deploy.ps1` so you can use this script to run the program.